### PR TITLE
Update adding-a-build-spec.md

### DIFF
--- a/_docs/adding-a-build-spec.md
+++ b/_docs/adding-a-build-spec.md
@@ -307,8 +307,10 @@ So a variation of the above with `$BASH_ENV` looks like this:
 
 ```yml
 before_compile:
-  - echo 'export MY_VAR=hello' >> $BASH_ENV
-  - echo $MY_VAR
+  - |
+    echo 'export MY_VAR=hello' >> $BASH_ENV
+    source $BASH_ENV
+  - echo $MY_VARs
 ```
 
 In this case `$MY_VAR` is loaded from `$BASH_ENV` and should be printed out correctly.

--- a/_docs/adding-a-build-spec.md
+++ b/_docs/adding-a-build-spec.md
@@ -308,7 +308,7 @@ So a variation of the above with `$BASH_ENV` looks like this:
 ```yml
 before_compile:
   - echo 'export MY_VAR=hello' >> $BASH_ENV && source $BASH_ENV
-  - echo $MY_VARs
+  - echo $MY_VAR
 ```
 
 In this case `$MY_VAR` is loaded from `$BASH_ENV` and should be printed out correctly.

--- a/_docs/adding-a-build-spec.md
+++ b/_docs/adding-a-build-spec.md
@@ -307,9 +307,7 @@ So a variation of the above with `$BASH_ENV` looks like this:
 
 ```yml
 before_compile:
-  - |
-    echo 'export MY_VAR=hello' >> $BASH_ENV
-    source $BASH_ENV
+  - echo 'export MY_VAR=hello' >> $BASH_ENV && source $BASH_ENV
   - echo $MY_VARs
 ```
 


### PR DESCRIPTION
The docs were incomplete with regards to persisting environment variables. It is important that the env is persisted across all future bash shells by performing `source $BASH_ENV`