### PR TITLE
Correct goenv command on build images docs

### DIFF
--- a/_docs/seed-build-images.md
+++ b/_docs/seed-build-images.md
@@ -106,7 +106,7 @@ Seed uses [goenv](https://github.com/syndbg/goenv) to manage Go versions. To use
 
 ```yml
 before_compile:
-  - cd $HOME/.goenv && git pull && goenv install 1.16.4 && global 1.16.4
+  - cd $HOME/.goenv && git pull && goenv install 1.16.4 && goenv global 1.16.4
 ```
 
 #### Customizing Python versions


### PR DESCRIPTION
The command to setup a global go version is `goenv global 1.x.x`, but the docs incorrectly have the command as `global 1.x.x`.